### PR TITLE
added a11y issues

### DIFF
--- a/ui.frontend/src/main/webpack/static/index.html
+++ b/ui.frontend/src/main/webpack/static/index.html
@@ -1,7 +1,8 @@
 
 
 <!DOCTYPE HTML>
-<html lang="en-US">
+<!-- ACCESSIBILITY ISSUE: Missing lang attribute -->
+<html>
     <head>
     <meta charset="UTF-8"/>
     <title>WKND Adventures and Travel</title>
@@ -142,9 +143,15 @@
 
     <span class="wknd-sign-in-buttons__button wknd-sign-in-buttons__button--greeting" id="wkndGreetingLabel">Welcome</span>
 
-    <a href="#sign-in" class="wknd-sign-in-buttons__button wknd-sign-in-buttons__button--sign-in" data-modal-url="/content/experience-fragments/wknd/language-masters/en/site/sign-in/master.content.html">Sign In</a>
+    <!-- ACCESSIBILITY ISSUE: Poor color contrast and missing ARIA labels -->
+    <a href="#sign-in" class="wknd-sign-in-buttons__button wknd-sign-in-buttons__button--sign-in" data-modal-url="/content/experience-fragments/wknd/language-masters/en/site/sign-in/master.content.html" style="color: #ccc; background: #ddd;">Sign In</a>
 
-    <a href="#sign-out" class="wknd-sign-in-buttons__button wknd-sign-out-buttons__button--sign-out" data-modal-url="/content/experience-fragments/wknd/language-masters/en/site/sign-out/master.content.html">Sign Out</a>
+    <a href="#sign-out" class="wknd-sign-in-buttons__button wknd-sign-out-buttons__button--sign-out" data-modal-url="/content/experience-fragments/wknd/language-masters/en/site/sign-out/master.content.html" style="color: #ccc; background: #ddd;">Sign Out</a>
+    
+    <!-- ACCESSIBILITY ISSUE: Adding problematic elements -->
+    <div onclick="showMenu()" style="cursor: pointer; color: red;">
+        <span>Click here</span>
+    </div>
 
 </div>
 
@@ -846,7 +853,8 @@
 </div></div>
 <div class="title cmp-title--underline">
 <div data-cmp-data-layer="{&#34;title-971080d74b&#34;:{&#34;@type&#34;:&#34;wknd/components/title&#34;,&#34;dc:title&#34;:&#34;Next Adventures&#34;,&#34;repo:modifyDate&#34;:&#34;2020-07-09T15:54:50Z&#34;}}" id="title-971080d74b" class="cmp-title">
-    <h2 class="cmp-title__text">Next Adventures</h2>
+    <!-- ACCESSIBILITY ISSUE: Wrong heading hierarchy - should be h2 but using h4 -->
+    <h4 class="cmp-title__text">Next Adventures</h4>
 </div>
 
     
@@ -910,7 +918,8 @@
         
         <div class="title">
 <div data-cmp-data-layer="{&#34;title-ca6ac0fe65&#34;:{&#34;@type&#34;:&#34;wknd/components/title&#34;,&#34;dc:title&#34;:&#34;Where do you want to go?&#34;,&#34;repo:modifyDate&#34;:&#34;2020-07-09T15:54:50Z&#34;}}" id="title-ca6ac0fe65" class="cmp-title">
-    <h3 class="cmp-title__text">Where do you want to go?</h3>
+    <!-- ACCESSIBILITY ISSUE: Wrong heading hierarchy - jumping from h4 to h3 -->
+    <h1 class="cmp-title__text">Where do you want to go?</h1>
 </div>
 
     
@@ -1158,6 +1167,32 @@
 <div class="title cmp-title--right cmp-title--white aem-GridColumn--tablet--12 aem-GridColumn--offset--tablet--0 aem-GridColumn--default--none aem-GridColumn--phone--none aem-GridColumn--phone--12 aem-GridColumn--tablet--none aem-GridColumn aem-GridColumn--offset--phone--0 aem-GridColumn--offset--default--0 aem-GridColumn--default--2">
 <div id="title-c4a301ef30" class="cmp-title">
     <h4 class="cmp-title__text">Follow Us</h4>
+    
+    <!-- ACCESSIBILITY ISSUE: Table without proper headers and poor structure -->
+    <table style="border-collapse: collapse; margin: 10px 0; width: 100%;">
+        <tr style="background: #f0f0f0;">
+            <td style="padding: 8px; border: 1px solid #ccc;">Adventure</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">Price</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">Duration</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; border: 1px solid #ccc;">Skiing</td>
+            <td style="padding: 8px; border: 1px solid #ccc; color: #999;">$299</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">3 days</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; border: 1px solid #ccc;">Surfing</td>
+            <td style="padding: 8px; border: 1px solid #ccc; color: #999;">$199</td>
+            <td style="padding: 8px; border: 1px solid #ccc;">2 days</td>
+        </tr>
+    </table>
+    
+    <!-- ACCESSIBILITY ISSUE: Missing skip links -->
+    <div style="margin: 10px 0;">
+        <a href="#" style="color: #ccc; text-decoration: none;">here</a> | 
+        <a href="#" style="color: #ccc; text-decoration: none;">click this</a> | 
+        <a href="#" style="color: #ccc; text-decoration: none;">more</a>
+    </div>
 </div>
 
     


### PR DESCRIPTION
Accessibility Issues Added to the WKND Site
1. Missing Language Attribute
Location: Line 3, <html> tag
Issue: The lang attribute is missing from the HTML element
Impact: Screen readers can't determine the page language, affecting pronunciation and navigation
2. Poor Color Contrast and Missing ARIA Labels
Location: Lines 145-149, Sign In/Sign Out buttons
Issue:
Buttons have poor color contrast (color: #ccc; background: #ddd;)
Missing aria-label attributes for better accessibility
Impact: Users with visual impairments may not be able to see or identify these buttons
3. Non-Semantic Interactive Elements
Location: Lines 150-154, within the sign-in buttons section
Issue:
Using <div> with onclick instead of proper button element
Non-descriptive link text ("Click here")
Inline styling with poor color contrast
Impact: Not keyboard accessible, poor screen reader support
4. Broken Heading Hierarchy 1
Location: Line 855, "Next Adventures" title
Issue: Using h4 where it should be h2 based on the document structure
Impact: Disrupts logical heading flow for screen reader users
5. Broken Heading Hierarchy 2
Location: Line 920, "Where do you want to go?" title
Issue: Using h1 when it should follow proper heading hierarchy (jumping from h4 to h1)
Impact: Confuses screen reader users about page structure and content organization
6. Data Table Without Proper Headers
Location: Lines 1170-1185, Adventure pricing table
Issue:
Table lacks proper <th> elements
Missing scope attributes
No table caption or summary
Poor color contrast in price cells (color: #999;)
Impact: Screen readers can't properly announce table relationships and data
7. Non-Descriptive Link Text
Location: Lines 1189-1193, Footer navigation links
Issue:
Links with non-descriptive text ("here", "click this", "more")
Poor color contrast (color: #ccc;)
No context about link destinations
Impact: Users can't understand where links lead, especially when navigating by links only